### PR TITLE
fix: use good status for `failed`

### DIFF
--- a/src/AppBundle/Command/UpdatePullRequestStatusCommand.php
+++ b/src/AppBundle/Command/UpdatePullRequestStatusCommand.php
@@ -59,7 +59,8 @@ class UpdatePullRequestStatusCommand extends ContainerAwareCommand
             case 'success':
                 $comment = "The pull request has been deployed";
                 break;
-            case 'failed':
+            case 'error':
+            case 'failure':
                 $comment = "The pull request cannot be deployed";
                 break;
             default:


### PR DESCRIPTION
Je sais pas si ça n'a jamais fonctionné ou si GitHub a changé le nom du status depuis, mais `failed` n'est pas présent dans la [liste des statuts](https://developer.github.com/v3/repos/statuses/#create-a-status).
Il faut utiliser `success`, `error`, `failure`, ou `pending`.